### PR TITLE
Fix sign when aggregating different account types

### DIFF
--- a/jgnash-core/src/main/java/jgnash/engine/budget/BudgetResultsModel.java
+++ b/jgnash-core/src/main/java/jgnash/engine/budget/BudgetResultsModel.java
@@ -469,9 +469,13 @@ public class BudgetResultsModel implements MessageListener {
                 final BudgetPeriodResults childResults = buildAccountResults(descriptor, child);
 
                 final BigDecimal exchangeRate = child.getCurrencyNode().getExchangeRate(account.getCurrencyNode());
+                
+                // reverse sign if the parent account is an income account but the child is not, or vice versa
+                final BigDecimal sign = ((account.getAccountType() == AccountType.INCOME) != 
+                        (child.getAccountType() == AccountType.INCOME)) ? BigDecimal.ONE.negate() : BigDecimal.ONE;
 
-                results.setChange(results.getChange().add(childResults.getChange().multiply(exchangeRate)));
-                results.setBudgeted(results.getBudgeted().add(childResults.getBudgeted().multiply(exchangeRate)));
+                results.setChange(results.getChange().add(childResults.getChange().multiply(exchangeRate).multiply(sign)));
+                results.setBudgeted(results.getBudgeted().add(childResults.getBudgeted().multiply(exchangeRate).multiply(sign)));
                 results.setRemaining(results.getRemaining().add(childResults.getRemaining().multiply(exchangeRate)));
             }
         } finally {

--- a/jgnash-swing/src/main/java/jgnash/ui/components/expandingtable/AbstractExpandingTableModel.java
+++ b/jgnash-swing/src/main/java/jgnash/ui/components/expandingtable/AbstractExpandingTableModel.java
@@ -319,12 +319,10 @@ public abstract class AbstractExpandingTableModel<E extends Comparable<? super E
      */
     protected ExpandingTableNode<E> getExpandingTableNodeAt(final int rowIndex) {
         // wait for the worker to complete
-        if (initWorker != null) {
-            try {                   
-                initWorker.get();
-            } catch (InterruptedException | ExecutionException ex) {
-                Logger.getLogger(AbstractExpandingTableModel.class.getName()).log(Level.SEVERE, null, ex);
-            }
+        try {                   
+            initWorker.get();
+        } catch (InterruptedException | ExecutionException ex) {
+            Logger.getLogger(AbstractExpandingTableModel.class.getName()).log(Level.SEVERE, null, ex);
         }
             
         ReadLock readLock = rwl.readLock();
@@ -493,7 +491,6 @@ public abstract class AbstractExpandingTableModel<E extends Comparable<? super E
         @Override
         protected void done() {
             fireNodeChanged();
-            initWorker = null;
         }
     }
 }


### PR DESCRIPTION
Income accounts in budgets work with a reversed sign, but this was not considered in the aggregation of child accounts.

The recurring check `account.getAccountType() == AccountType.INCOME` should probably be factored out into its own method, but I was not sure where to put it. It is used in `BudgetResultsModel.java` and `BudgetFactory.java`.