### PR TITLE
Format CSS strings with Locale.US

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/resource/font/FontAwesomeLabel.java
+++ b/jgnash-fx/src/main/java/jgnash/resource/font/FontAwesomeLabel.java
@@ -20,6 +20,7 @@ package jgnash.resource.font;
 import de.jensd.fx.glyphs.GlyphIcons;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView;
+import java.util.Locale;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringExpression;
@@ -68,7 +69,8 @@ public class FontAwesomeLabel extends Label {
 
     public FontAwesomeLabel(final GlyphIcons glyphValue, final Double sizeValue, Paint paint) {
 
-        final StringExpression iconStyleProperty = Bindings.format("-fx-font-family: FontAwesome; -fx-font-size: %1$.6f;",
+        final StringExpression iconStyleProperty = Bindings.format(Locale.US,
+                "-fx-font-family: FontAwesome; -fx-font-size: %1$.6f;",
                 ThemeManager.getFontScaleProperty().multiply(sizeValue));
 
         setGlyphName(glyphValue);

--- a/jgnash-fx/src/main/java/jgnash/uifx/skin/ThemeManager.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/skin/ThemeManager.java
@@ -17,6 +17,7 @@
  */
 package jgnash.uifx.skin;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.prefs.Preferences;
 
@@ -128,7 +129,7 @@ public class ThemeManager {
         });
 
         // Create the binding format for the style / font size
-        styleProperty = Bindings.format("-fx-font-size: %1$.6fem; -fx-base:%2$s",
+        styleProperty = Bindings.format(Locale.US, "-fx-font-size: %1$.6fem; -fx-base:%2$s",
                 fontScaleProperty, _baseColorProperty);
     }
 


### PR DESCRIPTION
Previously, a German default locale led to the format string
'-fx-font-size: 1,000000em; -fx-base:#ecececff' (with a comma instead
of a decimal point), which made all texts really tiny.

This might also fix the problem for which the workaround in commit
c27c449eb2477a5ac3590a6d6ec2c8f9008ce1ac was created.