### PR TITLE
Linking BarChart and Pie Chart

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpenseBarChartDialogController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpenseBarChartDialogController.java
@@ -45,6 +45,7 @@ import jgnash.engine.Engine;
 import jgnash.engine.EngineFactory;
 import jgnash.report.ReportPeriod;
 import jgnash.report.ReportPeriodUtils;
+import jgnash.resource.cursor.CustomCursor;
 import jgnash.text.CommodityFormat;
 import jgnash.uifx.Options;
 import jgnash.uifx.control.DatePickerEx;
@@ -209,6 +210,8 @@ public class IncomeExpenseBarChartDialogController {
             //PK: Now customize the data we are interested in
             pair.getController().setParameters(accountType, startDate, endDate);
         });
+
+        data.getNode().setOnMouseEntered(event -> data.getNode().setCursor(CustomCursor.getZoomInCursor()) );
     }
 
     private BigDecimal getSum(final List<Account> accounts, final LocalDate statDate, final LocalDate endDate) {

--- a/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpenseBarChartDialogController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpenseBarChartDialogController.java
@@ -50,6 +50,8 @@ import jgnash.uifx.Options;
 import jgnash.uifx.control.DatePickerEx;
 import jgnash.uifx.util.InjectFXML;
 import jgnash.time.DateUtils;
+import jgnash.uifx.util.FXMLUtils;
+import jgnash.util.ResourceUtils;
 
 /**
  * Income and Expense Bar Chart.
@@ -147,6 +149,8 @@ public class IncomeExpenseBarChartDialogController {
         final List<ReportPeriodUtils.Descriptor> descriptors = ReportPeriodUtils.getDescriptors(
                 periodComboBox.getValue(), startDatePicker.getValue(), endDatePicker.getValue());
 
+        int descriptorsIndex = 0;
+
         // Income Series
         final XYChart.Series<String, Number> incomeSeries = new XYChart.Series<>();
         incomeSeries.setName(AccountType.INCOME.toString());
@@ -171,17 +175,40 @@ public class IncomeExpenseBarChartDialogController {
             profitSeries.getData().add(new XYChart.Data<>(descriptor.getLabel(), income.add(expense)));
         }
 
+        descriptorsIndex = 0;
         for (XYChart.Data<String, Number> data : incomeSeries.getData()) {
             Tooltip.install(data.getNode(), new Tooltip(numberFormat.format(data.getYValue())));
+            setupPieChartLaunch(data, AccountType.INCOME,
+                    descriptors.get(descriptorsIndex).getStartDate(), descriptors.get(descriptorsIndex).getEndDate());
+            descriptorsIndex++;
         }
 
+        descriptorsIndex = 0;
         for (XYChart.Data<String, Number> data : expenseSeries.getData()) {
             Tooltip.install(data.getNode(), new Tooltip(numberFormat.format(data.getYValue())));
+            setupPieChartLaunch(data, AccountType.EXPENSE,
+                    descriptors.get(descriptorsIndex).getStartDate(), descriptors.get(descriptorsIndex).getEndDate());
+            descriptorsIndex++;
         }
 
         for (XYChart.Data<String, Number> data : profitSeries.getData()) {
             Tooltip.install(data.getNode(), new Tooltip(numberFormat.format(data.getYValue())));
         }
+    }
+
+    private void setupPieChartLaunch(final XYChart.Data<String, Number> data, final AccountType accountType, 
+            final LocalDate startDate, final LocalDate endDate){
+        //PK: Launch the PieChartNormally on click
+        data.getNode().setOnMouseClicked(event -> {
+            final FXMLUtils.Pair<IncomeExpensePieChartDialogController> pair = 
+                    FXMLUtils.load(IncomeExpensePieChartDialogController.class.getResource("IncomeExpensePieChartDialog.fxml"),
+                        ResourceUtils.getString("Title.IncomeExpenseChart"));
+
+            pair.getStage().show();
+
+            //PK: Now customize the data we are interested in
+            pair.getController().setParameters(accountType, startDate, endDate);
+        });
     }
 
     private BigDecimal getSum(final List<Account> accounts, final LocalDate statDate, final LocalDate endDate) {

--- a/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpensePieChartDialogController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpensePieChartDialogController.java
@@ -127,7 +127,7 @@ public class IncomeExpensePieChartDialogController {
         startDatePicker.valueProperty().addListener(listener);
         endDatePicker.valueProperty().addListener(listener);
 
-        pieChart.setLegendSide(Side.RIGHT);
+        pieChart.setLegendSide(Side.BOTTOM);
 
         // zoom out
         pieChart.setOnMouseClicked(event -> {

--- a/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpensePieChartDialogController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/report/IncomeExpensePieChartDialogController.java
@@ -18,6 +18,7 @@
 package jgnash.uifx.report;
 
 import java.text.NumberFormat;
+import java.time.LocalDate;
 import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.prefs.Preferences;
@@ -228,6 +229,23 @@ public class IncomeExpensePieChartDialogController {
         } else {
             pieChart.setData(FXCollections.emptyObservableList());
             pieChart.setTitle("No Data");
+        }
+    }
+
+    public void setParameters( final AccountType accountType, final LocalDate startDate, final LocalDate endDate ) {
+        //PK: dates can be directly set
+        startDatePicker.setValue(startDate);
+        endDatePicker.setValue(endDate);
+
+        //PK: We assume that the root of all income or expense accounts is one account under the root. Select that
+        final Engine engine = EngineFactory.getEngine(EngineFactory.DEFAULT);
+        Objects.requireNonNull(engine);
+
+        for ( final Account comboAccount : accountComboBox.getItems() ) {
+            if ( (accountType == comboAccount.getAccountType()) && (comboAccount.getParent() == engine.getRootAccount()) ) {
+                accountComboBox.setValue(comboAccount);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
1) Allows users to click on the Income and Expense Bars on the chart and it launches the PieChart for the corresponding account and date range

2) Show legend on the bottom for the PieChart. Looks neater but it might be a personal preference. You may skip this second commit.