### PR TITLE
allow open dialog to resize in width

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/StaticUIMethods.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/StaticUIMethods.java
@@ -55,10 +55,11 @@ public class StaticUIMethods {
                 = FXMLUtils.load(OpenDatabaseController.class.getResource("OpenDatabaseForm.fxml"),
                 ResourceUtils.getString("Title.Open"));
 
-        pair.getStage().setResizable(false);
+        pair.getStage().setResizable(true);
 
         StageUtils.addBoundsListener(pair.getStage(), OpenDatabaseController.class, MainView.getPrimaryStage());
 
+        pair.getStage().setMaxHeight(pair.getStage().getHeight());
         pair.getStage().show();
     }
 

--- a/jgnash-fx/src/main/resources/jgnash/uifx/views/main/OpenDatabaseForm.fxml
+++ b/jgnash-fx/src/main/resources/jgnash/uifx/views/main/OpenDatabaseForm.fxml
@@ -17,7 +17,7 @@
           fx:controller="jgnash.uifx.views.main.OpenDatabaseController" styleClass="form, dialog">
     <columnConstraints>
         <ColumnConstraints hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity"/>
-        <ColumnConstraints hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity"/>
+        <ColumnConstraints hgrow="ALWAYS" maxWidth="Infinity" minWidth="-Infinity"/>
         <ColumnConstraints hgrow="NEVER" maxWidth="-Infinity" minWidth="-Infinity"/>
     </columnConstraints>
     <rowConstraints>


### PR DESCRIPTION
Minor fix to the open dialog. I have a few files I use that reside on a longer filepath and its not always easy to see which one is selected so made this small change.