### PR TITLE
Fix the URL to the local Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <repository>
             <id>jgnash-local</id>
             <name>Local repository in project tree</name>
-            <url>file:${basedir}/../repository</url>
+            <url>file://${basedir}/../repository</url>
         </repository>
 
         <repository>


### PR DESCRIPTION
Like the name says, the repo is *in* the project tree, not outside of
it. Also fix the URL prefix to say "file://".