### PR TITLE
Ignore cash transfers for dividends in realized gains

### DIFF
--- a/jgnash-core/src/main/java/jgnash/engine/InvestmentPerformanceSummary.java
+++ b/jgnash-core/src/main/java/jgnash/engine/InvestmentPerformanceSummary.java
@@ -193,7 +193,7 @@ public class InvestmentPerformanceSummary {
                             totalSales = totalSales.add(price.multiply(quantity).subtract(fees));
                             break;
                         case DIVIDEND:
-                            totalSales = totalSales.add(t.getTotal(t.getInvestmentAccount()).multiply(rate));
+                            totalSales = totalSales.add(t.getTotalWithoutCashTransfer(t.getInvestmentAccount()).multiply(rate));
                             break;
                         case REINVESTDIV:
                             totalSales = totalSales.add(t.getTotal(t.getInvestmentAccount()).multiply(rate)).subtract(fees);

--- a/jgnash-core/src/main/java/jgnash/engine/InvestmentTransaction.java
+++ b/jgnash-core/src/main/java/jgnash/engine/InvestmentTransaction.java
@@ -254,6 +254,31 @@ public class InvestmentTransaction extends Transaction {
     }
 
     /**
+     * Calculates the total of the value of the shares, gains, fees, etc. as it
+     * pertains to an account, but leaves out any cash transfer.
+     * <p>
+     * @param account The {@code Account} to calculate the total against
+     * @return total resulting total for this transaction
+     * @see getTotal()
+     */
+    public BigDecimal getTotalWithoutCashTransfer(final Account account) {
+
+        BigDecimal total = BigDecimal.ZERO;
+
+        for (final TransactionEntry e : transactionEntries) {
+            if (e.getTransactionTag() != TransactionTag.INVESTMENT_CASH_TRANSFER) {
+                if (e instanceof AbstractInvestmentTransactionEntry) {
+                    total = total.add(((AbstractInvestmentTransactionEntry) e).getTotal());
+                } else {
+                    total = total.add(e.getAmount(account));
+                }
+            }
+        }
+
+        return total;
+    }
+    
+    /**
      * Calculates the total cash value of the transaction.
      * <p>
      * <b>Not intended for use to calculate account balances</b>


### PR DESCRIPTION
Every dividend transaction contains two transaction entries, one of
which is just the transfer to the cash account. When calculating the
realized gains, this cash transfer has to be ignored.

Previously, the realized gains from dividends were always zero
because the two transactions canceled each other out.

I'm not sure that I identified the problem completely. This fixes the
problem for dividends, but it my be necessary to fix this in similar
situations, too.