### PR TITLE
Checkbox to autocomplete the ending balance. Text needs localization.

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/views/register/reconcile/ReconcileSettingsDialogController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/views/register/reconcile/ReconcileSettingsDialogController.java
@@ -28,6 +28,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.FXML;
 import javafx.scene.Scene;
 import javafx.scene.control.ButtonBar;
+import javafx.scene.control.CheckBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 
@@ -67,6 +68,9 @@ public class ReconcileSettingsDialogController {
     private DecimalTextField closingBalanceTextField;
 
     @FXML
+    private CheckBox autofillClosingBalanceCheckBox;
+
+    @FXML
     private DatePickerEx datePicker;
 
     private final ObjectProperty<Account> account = new SimpleObjectProperty<>();
@@ -92,6 +96,10 @@ public class ReconcileSettingsDialogController {
         // Last date of the month for the 1st unreconciled transaction
         LocalDate statementDate = account.getFirstUnreconciledTransactionDate().with(TemporalAdjusters.lastDayOfMonth());
 
+        determineBalances(account, statementDate);
+    }
+
+    private void determineBalances(final Account account, LocalDate statementDate) {
         // Balance at the 1st unreconciled transaction
         BigDecimal openingBalance = AccountBalanceDisplayManager.convertToSelectedBalanceMode(account.getAccountType(),
                 account.getOpeningBalanceForReconcile());
@@ -145,6 +153,16 @@ public class ReconcileSettingsDialogController {
         datePicker.setValue(statementDate);
         openingBalanceTextField.setDecimal(openingBalance);
         closingBalanceTextField.setDecimal(closingBalance);
+    }
+
+    @FXML
+    private void handleUpdateBalance() {
+        final Account account = accountProperty().get();
+        LocalDate statementDate = datePicker.getValue();
+
+        if (autofillClosingBalanceCheckBox.isSelected()) {
+            determineBalances(account, statementDate);
+        }
     }
 
     @FXML

--- a/jgnash-fx/src/main/resources/jgnash/uifx/views/register/reconcile/ReconcileSettingsDialog.fxml
+++ b/jgnash-fx/src/main/resources/jgnash/uifx/views/register/reconcile/ReconcileSettingsDialog.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ButtonBar?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
@@ -22,15 +23,17 @@
         <RowConstraints vgrow="NEVER"/>
         <RowConstraints vgrow="NEVER"/>
         <RowConstraints vgrow="NEVER"/>
+        <RowConstraints vgrow="NEVER"/>
     </rowConstraints>
 
     <Label text="%Label.StatementDate"/>
-    <DatePickerEx fx:id="datePicker" maxWidth="Infinity" GridPane.columnIndex="1"/>
+    <DatePickerEx fx:id="datePicker" maxWidth="Infinity" onAction="#handleUpdateBalance" GridPane.columnIndex="1"/>
     <Label text="%Label.OpeningBalance" GridPane.rowIndex="1"/>
     <DecimalTextField fx:id="openingBalanceTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
     <Label text="%Label.EndingBalance" GridPane.rowIndex="2"/>
     <DecimalTextField fx:id="closingBalanceTextField" GridPane.columnIndex="1" GridPane.rowIndex="2"/>
-    <ButtonBar fx:id="buttonBar" GridPane.columnSpan="2" GridPane.rowIndex="3">
+    <CheckBox fx:id="autofillClosingBalanceCheckBox" text="Calculate Ending Balance" onAction="#handleUpdateBalance" GridPane.columnSpan="2" GridPane.rowIndex="3"/>
+    <ButtonBar fx:id="buttonBar" GridPane.columnSpan="2" GridPane.rowIndex="4">
         <buttons>
             <Button text="%Button.Ok" onAction="#handleOkayAction"/>
             <Button text="%Button.Cancel" onAction="#handleCloseAction"/>


### PR DESCRIPTION
The statements for almost all my accounts do not come on month end. I need to reconcile on random dates which needs to manually type in the balance amount. This patch allows the reconcile dialog to pick the balances from the account for the date specified by user to reconcile on.