### PR TITLE
Reminders dialog tweaks

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/control/TimePeriodComboBox.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/control/TimePeriodComboBox.java
@@ -45,8 +45,6 @@ public class TimePeriodComboBox extends ComboBox<String> {
         // Update the period property automatically
         valueProperty().addListener((observable, oldValue, newValue)
                 -> period.setValue(periods[getSelectionModel().getSelectedIndex()]));
-
-        JavaFXUtils.runLater(() -> setSelectedPeriod(getPeriods()[0]));
     }
 
     public ReadOnlyIntegerProperty periodProperty() {

--- a/jgnash-fx/src/main/java/jgnash/uifx/views/recurring/NotificationDialog.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/views/recurring/NotificationDialog.java
@@ -80,6 +80,8 @@ class NotificationDialog extends Stage implements MessageListener {
 
     private final ObservableList<PendingReminder> observableReminderList = FXCollections.observableArrayList();
 
+    private boolean isSnoozed = false;
+
     NotificationDialog() {
         FXMLUtils.loadFXML(this, "NotificationDialog.fxml", ResourceUtils.getBundle());
         setTitle(ResourceUtils.getString("Title.Reminder"));
@@ -162,11 +164,17 @@ class NotificationDialog extends Stage implements MessageListener {
 
     private void handleCancelAction() {
         observableReminderList.clear(); // dump the list so caller sees nothing
+        isSnoozed = true;
         close();
     }
 
     private void handleOkayAction() {
+        isSnoozed = false;
         close();
+    }
+
+    public final boolean isSnoozed() {
+        return isSnoozed;
     }
 
     @Override


### PR DESCRIPTION
Hi, I made some changes to the Reminders dialog box to address the following:
- Choosing the Sleep button always resulted in the reminder time being reset to 5 minutes. 
- If Sleep was chosen and there were still open reminders, the reminders dialog would also pop up after the 45 second startup time delay instead of sleeping for the appropriate time.
- If the Reminders dialog box was open and the reminder timer expired, new reminder dialog boxes would open.

The change to TimePeriodComboBox.java takes care of the reminder time always being reset to 5 minutes, the changes to the other two files are for the other issues.