### PR TITLE
Field :61: could start with a character instead of a number

### DIFF
--- a/mt940/src/main/java/net/bzzt/swift/mt940/parser/Mt940Parser.java
+++ b/mt940/src/main/java/net/bzzt/swift/mt940/parser/Mt940Parser.java
@@ -205,6 +205,13 @@ public class Mt940Parser {
 
         String decimal = line.substring(0, endIndex);
         decimal = decimal.replaceAll(",", ".");
+
+        // According to the MT940 Standard the amount (field :61:) could start with the last character of the currency
+        // e.g. R for EUR
+        // See: https://www.kontopruef.de/mt940s.shtml
+        // This code removes any character which is not a decimal or point.
+        decimal = decimal.replaceAll("[^\\d.]", "");
+
         currentEntry.setBetrag(new BigDecimal(decimal));
 
         return line.substring(endIndex);


### PR DESCRIPTION
My banks (Sparkasse) MT940 export was not able to be loaded. I debugged and found out that the MT940 standard can (optional) have a character in front of the amount. This would be the last character of the currency. In my case Euro -> EUR it would be R.
The pull request will remove any non numeric character from the amount.