### PR TITLE
Prevent exception when editing securities with no ISIN

### DIFF
--- a/jgnash-core/src/main/java/jgnash/engine/SecurityNode.java
+++ b/jgnash-core/src/main/java/jgnash/engine/SecurityNode.java
@@ -134,7 +134,7 @@ public class SecurityNode extends CommodityNode {
     }
 
     public String getISIN() {
-        return isin;
+        return (isin == null)?"":isin;
     }
 
     public void setISIN(final String isin) {


### PR DESCRIPTION
Minor fix. I was getting exceptions when maintaining securities as they did not have the ISIN.