### PR TITLE
Uncaught exceptions loop when date picker text is empty

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/control/DatePickerEx.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/control/DatePickerEx.java
@@ -180,6 +180,12 @@ public class DatePickerEx extends DatePicker {
                 default:
             }
         });
+
+        valueProperty().addListener(new WeakChangeListener<>((observable, oldValue, newValue) -> {
+            if (newValue == null) {
+                setValue(oldValue);
+            }
+        }));
     }
 
     private LocalDate _getValue() {


### PR DESCRIPTION
There is an uncaught exceptions loop when you clear the date picker value and then switch the focus. 
How to reproduce:
1. Open a transaction editor.
2. Clear the text in the date picker
3. Switch focus from the date picker

Sometimes there is only one exception, but often there is unstoppable loop. 