### PR TITLE
Double click does not set current directory on MacOS

### DIFF
--- a/jGnash
+++ b/jGnash
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
-./bin/bootloader "$@"
+cwd=$(dirname $0)
+$cwd/bin/bootloader "$@"


### PR DESCRIPTION
These changes should work on all Unix like systems I hope. Changes the use of relative path to absolute.