### PR TITLE
Improve lib path determination to not depend on current working directory

### DIFF
--- a/bootloader/src/main/java/jgnash/bootloader/BootLoader.java
+++ b/bootloader/src/main/java/jgnash/bootloader/BootLoader.java
@@ -25,11 +25,13 @@ import javax.xml.bind.DatatypeConverter;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -93,7 +95,15 @@ public class BootLoader {
     }
 
     private static String getLibPath() {
-        return Paths.get(Paths.get(System.getProperty(USER_DIR)).toString() + SEPARATOR + LIB).toString();
+        // Current class lives in a .jar that lives in the lib folder we want to populate.  Let's
+        // use that to find the lib path rather than depend on jGnash being invoked from the correct
+        // folder.
+        // https://stackoverflow.com/questions/320542/how-to-get-the-path-of-a-running-jar-file?noredirect=1&lq=1
+        try {
+            return new File(BootLoader.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getPath();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to determine jGnash lib path");
+        }
     }
 
     public static String getOS() {


### PR DESCRIPTION
The old code would always populate a "lib" folder relative to the folder jGnash was launched from.  So it worked if you were in the install folder, but not otherwise.

Not sure how you feel about the RuntimeException; I could replace it with the original behavior?