### PR TITLE
Fix typos in moduleName in 2 places

### DIFF
--- a/jgnash-core/build.gradle
+++ b/jgnash-core/build.gradle
@@ -1,7 +1,7 @@
 description = "jGnash Core"
 
 project.ext {
-    moduleName = "jgnash-core"
+    moduleName = "jgnash.core"
 }
 
 dependencies {

--- a/jgnash-resources/build.gradle
+++ b/jgnash-resources/build.gradle
@@ -4,7 +4,7 @@ import static org.gradle.internal.os.OperatingSystem.*
 description = "jGnash Resources"
 
 project.ext {
-    moduleName = "jgnash.convert"
+    moduleName = "jgnash.resources"
 
     javaVersion = Jvm.current()
     osName = current()


### PR DESCRIPTION
I was investigating #85 and discovered two minor typos in the `moduleName` settings that show up in the automatic-module-name header.

This should fix some compile issues I'm seeing in trying to get JPMS working.
