### PR TITLE
When using 'Copy to Clipboard', include sign of transaction value

### DIFF
--- a/jgnash-fx/src/main/java/jgnash/uifx/views/register/RegisterTableController.java
+++ b/jgnash-fx/src/main/java/jgnash/uifx/views/register/RegisterTableController.java
@@ -528,7 +528,7 @@ abstract class RegisterTableController {
         builder.append('\t');
         builder.append(transaction.getReconciled(transaction.getCommonAccount()).toString());
         builder.append('\t');
-        builder.append(transaction.getAmount(transaction.getCommonAccount()).toPlainString());
+        builder.append(transaction.getAmount(this.account.get()).toPlainString());
 
         return builder.toString();
     }


### PR DESCRIPTION
Consider this scenario:
1. Open an account that includes a mix of debits and credits.
2. Select several transactions.
3. Right click, select "Copy to Clipboard".

Before this change, the amount of all transactions would be positive.
After this change, credits have a positive value while debits have a
negative value.